### PR TITLE
[Feature] Use language.md to track multi-lang.

### DIFF
--- a/assets/js/manual.js
+++ b/assets/js/manual.js
@@ -53,6 +53,22 @@
         }).send();
     }
 
+    var populateLanguage = function() {
+        var markdownRequest = new Request({
+            "url": here + 'manual/' + locale + '/language.md',
+            "method": "get",
+            "onSuccess": function (response) {
+                var parser = new DOMParser(),
+                    list = parser.parseFromString(marked(response), 'text/xml');
+
+                $$(list.getElementsByTagName('li')).each(
+                    function(item) {
+                        $('language-items').grab(item);
+                    });
+            }
+        }).send();
+    }
+
     var populateVersion = function() {
         var versionRequest = new Request({
             "url": here + 'manual/' + locale + '/version.md',
@@ -89,10 +105,11 @@
             }
         })
         populateMenu();
+        populateLanguage();
         populateWindow(currentDoc);
         populateVersion();
 
-        document.id('language-item').addEvent('click:relay(a)', function (event, target) {
+        document.id('language-items').addEvent('click:relay(a)', function (event, target) {
             locale = target.get('href');
             populateMenu();
             populateWindow(currentDoc);

--- a/index.html
+++ b/index.html
@@ -41,9 +41,7 @@
                 <span id="language-select">English</span>
                 <b class="caret"></b>
               </a>
-              <ul id="language-item" class="dropdown-menu">
-                <li><a href="en-US">English</a></li>
-                <li><a href="zh-TW">中文 (繁體)</a></li>
+              <ul id="language-items" class="dropdown-menu">
               </ul>
             </li>
           </ul>

--- a/manual/en-US/language.md
+++ b/manual/en-US/language.md
@@ -1,0 +1,2 @@
+- [English](en-US)
+- [中文 (繁體)](zh-TW)

--- a/manual/language.md
+++ b/manual/language.md
@@ -1,0 +1,2 @@
+- [English](en-US)
+- [中文 (繁體)](zh-TW)


### PR DESCRIPTION
In folder `manual/en-US` or `manual/en-TW` etc., we add `language.md` files.

These markdown files will be load in runtime.

One can add multi-languages support by mantaining `language.md`.
